### PR TITLE
fit calibrators at `fit.container()`

### DIFF
--- a/R/adjust-numeric-calibration.R
+++ b/R/adjust-numeric-calibration.R
@@ -29,8 +29,14 @@
 #' @export
 adjust_numeric_calibration <- function(x, type = NULL) {
   # to-do: add argument specifying `prop` in initial_split
-  check_container(x)
-  type <- check_type(type, x$type)
+  check_container(x, calibration_type = "numeric")
+  # wait to `check_type()` until `fit()` time
+  if (!is.null(type)) {
+    arg_match0(
+      type,
+      c("linear", "isotonic", "isotonic_boot")
+    )
+  }
 
   op <-
     new_operation(
@@ -61,12 +67,13 @@ print.numeric_calibration <- function(x, ...) {
 
 #' @export
 fit.numeric_calibration <- function(object, data, container = NULL, ...) {
+  type <- check_type(object$type, container$type)
   # todo: adjust_numeric_calibration() should take arguments to pass to
   # cal_estimate_* via dots
   fit <-
     eval_bare(
       call2(
-        paste0("cal_estimate_", object$arguments$type),
+        paste0("cal_estimate_", type),
         .data = data,
         truth = container$columns$outcome,
         estimate = container$columns$estimate,

--- a/R/adjust-probability-calibration.R
+++ b/R/adjust-probability-calibration.R
@@ -8,8 +8,14 @@
 #' @export
 adjust_probability_calibration <- function(x, type = NULL) {
   # to-do: add argument specifying `prop` in initial_split
-  check_container(x)
-  type <- check_type(type, x$type)
+  check_container(x, calibration_type = "probability")
+  # wait to `check_type()` until `fit()` time
+  if (!is.null(type)) {
+    arg_match(
+      type,
+      c("logistic", "multinomial", "beta", "isotonic", "isotonic_boot")
+    )
+  }
 
   op <-
     new_operation(
@@ -40,13 +46,14 @@ print.probability_calibration <- function(x, ...) {
 
 #' @export
 fit.probability_calibration <- function(object, data, container = NULL, ...) {
+  type <- check_type(object$type, container$type)
   # todo: adjust_probability_calibration() should take arguments to pass to
   # cal_estimate_* via dots
   # to-do: add argument specifying `prop` in initial_split
   fit <-
     eval_bare(
       call2(
-        paste0("cal_estimate_", object$type),
+        paste0("cal_estimate_", type),
         .data = data,
         # todo: make getters for the entries in `columns`
         truth = container$columns$outcome,

--- a/R/container.R
+++ b/R/container.R
@@ -130,7 +130,7 @@ fit.container <- function(object, .data, outcome, estimate, probabilities = c(),
 
   num_oper <- length(object$operations)
   for (op in seq_len(num_oper)) {
-    object$operations[[op]] <- fit(object$operations[[op]], data, object)
+    object$operations[[op]] <- fit(object$operations[[op]], .data, object)
     .data <- predict(object$operations[[op]], .data, object)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,3 +60,52 @@ check_container <- function(x, call = caller_env(), arg = caller_arg(x)) {
 
   invisible()
 }
+
+types_regression <- c("linear", "isotonic", "isotonic_boot")
+types_binary <- c("logistic", "beta", "isotonic", "isotonic_boot")
+types_multiclass <- c("multinomial", "beta", "isotonic", "isotonic_boot")
+check_type <- function(adjust_type,
+                       container_type,
+                       arg = caller_arg(adjust_type),
+                       call = caller_env()) {
+  # to-do: handle unknown container type (#11 ish)
+  if (is.null(adjust_type)) {
+    switch(
+      container_type,
+      regression = return("linear"),
+      binary = return("logistic"),
+      multiclass = return("multinomial")
+    )
+  }
+
+  switch(
+    container_type,
+    regression = arg_match0(
+      adjust_type,
+      types_regression,
+      arg_nm = arg,
+      error_call = call
+    ),
+    binary = arg_match0(
+      adjust_type,
+      types_binary,
+      arg_nm = arg,
+      error_call = call
+    ),
+    multiclass = arg_match0(
+      adjust_type,
+      types_multiclass,
+      arg_nm = arg,
+      error_call = call
+    ),
+    arg_match0(
+      adjust_type,
+      unique(c(types_regression, types_binary, types_multiclass)),
+      arg_nm = arg,
+      error_call = call
+    )
+  )
+
+  adjust_type
+}
+

--- a/man/adjust_numeric_calibration.Rd
+++ b/man/adjust_numeric_calibration.Rd
@@ -4,13 +4,16 @@
 \alias{adjust_numeric_calibration}
 \title{Re-calibrate numeric predictions}
 \usage{
-adjust_numeric_calibration(x, calibrator)
+adjust_numeric_calibration(x, type = NULL)
 }
 \arguments{
 \item{x}{A \code{\link[=container]{container()}}.}
 
-\item{calibrator}{A pre-trained calibration method from the \pkg{probably}
-package, such as \code{\link[probably:cal_estimate_linear]{probably::cal_estimate_linear()}}.}
+\item{type}{Character. One of \code{"linear"}, \code{"isotonic"}, or
+\code{"isotonic_boot"}, corresponding to the function from the \pkg{probably}
+package \code{\link[probably:cal_estimate_linear]{probably::cal_estimate_linear()}},
+\code{\link[probably:cal_estimate_isotonic]{probably::cal_estimate_isotonic()}}, or
+\code{\link[probably:cal_estimate_isotonic_boot]{probably::cal_estimate_isotonic_boot()}}, respectively.}
 }
 \description{
 Re-calibrate numeric predictions
@@ -26,16 +29,13 @@ dat <- tibble(y = rnorm(100), y_pred = y/2 + rnorm(100))
 
 dat
 
-# calibrate numeric predictions
-reg_cal <- cal_estimate_linear(dat, truth = y, estimate = y_pred)
-
 # specify calibration
 reg_ctr <-
   container(mode = "regression") \%>\%
-  adjust_numeric_calibration(reg_cal)
+  adjust_numeric_calibration(type = "linear")
 
-# "train" container
+# train container
 reg_ctr_trained <- fit(reg_ctr, dat, outcome = y, estimate = y_pred)
 
-predict(reg_ctr, dat)
+predict(reg_ctr_trained, dat)
 }

--- a/man/adjust_probability_calibration.Rd
+++ b/man/adjust_probability_calibration.Rd
@@ -4,13 +4,15 @@
 \alias{adjust_probability_calibration}
 \title{Re-calibrate classification probability predictions}
 \usage{
-adjust_probability_calibration(x, calibrator)
+adjust_probability_calibration(x, type = NULL)
 }
 \arguments{
 \item{x}{A \code{\link[=container]{container()}}.}
 
-\item{calibrator}{A pre-trained calibration method from the \pkg{probably}
-package, such as \code{\link[probably:cal_estimate_logistic]{probably::cal_estimate_logistic()}}.}
+\item{type}{Character. One of \code{"logistic"}, \code{"multinomial"},
+\code{"beta"}, \code{"isotonic"}, or \code{"isotonic_boot"}, corresponding to the
+function from the \pkg{probably} package \code{\link[probably:cal_estimate_logistic]{probably::cal_estimate_logistic()}},
+\code{\link[probably:cal_estimate_multinomial]{probably::cal_estimate_multinomial()}}, etc., respectively.}
 }
 \description{
 Re-calibrate classification probability predictions

--- a/tests/testthat/_snaps/adjust-numeric-calibration.md
+++ b/tests/testthat/_snaps/adjust-numeric-calibration.md
@@ -23,5 +23,14 @@
       container("classification", "binary") %>% adjust_numeric_calibration("linear")
     Condition
       Error in `adjust_numeric_calibration()`:
-      ! `type` must be one of "logistic", "beta", "isotonic", or "isotonic_boot", not "linear".
+      ! A binary container is incompatible with the operation `adjust_numeric_calibration()`.
+
+---
+
+    Code
+      container("regression", "regression") %>% adjust_numeric_calibration("binary")
+    Condition
+      Error in `adjust_numeric_calibration()`:
+      ! `type` must be one of "linear", "isotonic", or "isotonic_boot", not "binary".
+      i Did you mean "linear"?
 

--- a/tests/testthat/_snaps/adjust-numeric-calibration.md
+++ b/tests/testthat/_snaps/adjust-numeric-calibration.md
@@ -1,35 +1,27 @@
 # adjustment printing
 
     Code
-      ctr_reg %>% adjust_numeric_calibration(dummy_reg_cal)
+      ctr_reg %>% adjust_numeric_calibration()
     Message
       
       -- Container -------------------------------------------------------------------
-      A postprocessor with 1 operation:
+      A regression postprocessor with 1 operation:
       
       * Re-calibrate numeric predictions.
 
 # errors informatively with bad input
 
     Code
-      adjust_numeric_calibration(ctr_reg)
-    Condition
-      Error in `adjust_numeric_calibration()`:
-      ! `calibrator` is absent but must be supplied.
-
----
-
-    Code
       adjust_numeric_calibration(ctr_reg, "boop")
     Condition
       Error in `adjust_numeric_calibration()`:
-      ! `calibrator` should be a <cal_regression> object (`?probably::cal_estimate_linear()`), not a string.
+      ! `type` must be one of "linear", "isotonic", or "isotonic_boot", not "boop".
 
 ---
 
     Code
-      adjust_numeric_calibration(ctr_cls, dummy_cls_cal)
+      container("classification", "binary") %>% adjust_numeric_calibration("linear")
     Condition
       Error in `adjust_numeric_calibration()`:
-      ! `calibrator` should be a <cal_regression> object (`?probably::cal_estimate_linear()`), not a <cal_binary> object.
+      ! `type` must be one of "logistic", "beta", "isotonic", or "isotonic_boot", not "linear".
 

--- a/tests/testthat/_snaps/adjust-numeric-range.md
+++ b/tests/testthat/_snaps/adjust-numeric-range.md
@@ -5,7 +5,7 @@
     Message
       
       -- Container -------------------------------------------------------------------
-      A postprocessor with 1 operation:
+      A regression postprocessor with 1 operation:
       
       * Constrain numeric predictions to be between [-Inf, Inf].
 
@@ -16,7 +16,7 @@
     Message
       
       -- Container -------------------------------------------------------------------
-      A postprocessor with 1 operation:
+      A regression postprocessor with 1 operation:
       
       * Constrain numeric predictions to be between [?, Inf].
 
@@ -27,7 +27,7 @@
     Message
       
       -- Container -------------------------------------------------------------------
-      A postprocessor with 1 operation:
+      A regression postprocessor with 1 operation:
       
       * Constrain numeric predictions to be between [-1, ?].
 
@@ -38,7 +38,7 @@
     Message
       
       -- Container -------------------------------------------------------------------
-      A postprocessor with 1 operation:
+      A regression postprocessor with 1 operation:
       
       * Constrain numeric predictions to be between [?, 1].
 

--- a/tests/testthat/_snaps/adjust-probability-calibration.md
+++ b/tests/testthat/_snaps/adjust-probability-calibration.md
@@ -1,7 +1,7 @@
 # adjustment printing
 
     Code
-      ctr_cls %>% adjust_probability_calibration(dummy_cls_cal)
+      ctr_cls %>% adjust_probability_calibration("logistic")
     Message
       
       -- Container -------------------------------------------------------------------
@@ -12,24 +12,18 @@
 # errors informatively with bad input
 
     Code
-      adjust_probability_calibration(ctr_cls)
-    Condition
-      Error in `adjust_probability_calibration()`:
-      ! `calibrator` is absent but must be supplied.
-
----
-
-    Code
       adjust_probability_calibration(ctr_cls, "boop")
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `calibrator` should be a <cal_binary> or <cal_multinomial> object (`?probably::cal_estimate_logistic()`), not a string.
+      ! `type` must be one of "linear", "isotonic", "isotonic_boot", "logistic", "beta", or "multinomial", not "boop".
 
 ---
 
     Code
-      adjust_probability_calibration(ctr_cls, dummy_reg_cal)
+      container("regression", "regression") %>% adjust_probability_calibration(
+        "binary")
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `calibrator` should be a <cal_binary> or <cal_multinomial> object (`?probably::cal_estimate_logistic()`), not a <cal_regression> object.
+      ! `type` must be one of "linear", "isotonic", or "isotonic_boot", not "binary".
+      i Did you mean "linear"?
 

--- a/tests/testthat/_snaps/adjust-probability-calibration.md
+++ b/tests/testthat/_snaps/adjust-probability-calibration.md
@@ -15,7 +15,7 @@
       adjust_probability_calibration(ctr_cls, "boop")
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `type` must be one of "linear", "isotonic", "isotonic_boot", "logistic", "beta", or "multinomial", not "boop".
+      ! `type` must be one of "logistic", "multinomial", "beta", "isotonic", or "isotonic_boot", not "boop".
 
 ---
 
@@ -24,6 +24,14 @@
         "binary")
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `type` must be one of "linear", "isotonic", or "isotonic_boot", not "binary".
-      i Did you mean "linear"?
+      ! A regression container is incompatible with the operation `adjust_probability_calibration()`.
+
+---
+
+    Code
+      container("classification", "binary") %>% adjust_probability_calibration(
+        "linear")
+    Condition
+      Error in `adjust_probability_calibration()`:
+      ! `type` must be one of "logistic", "multinomial", "beta", "isotonic", or "isotonic_boot", not "linear".
 

--- a/tests/testthat/_snaps/validation-rules.md
+++ b/tests/testthat/_snaps/validation-rules.md
@@ -14,7 +14,7 @@
         adjust_probability_calibration()
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `type` must be a string or character vector.
+      ! Operations that change the hard class predictions must come after operations that update the class probability estimates.
 
 ---
 
@@ -24,7 +24,7 @@
         adjust_probability_calibration()
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `type` must be a string or character vector.
+      ! Operations that change the hard class predictions must come after operations that update the class probability estimates.
 
 ---
 

--- a/tests/testthat/_snaps/validation-rules.md
+++ b/tests/testthat/_snaps/validation-rules.md
@@ -2,8 +2,7 @@
 
     Code
       container(mode = "regression") %>% adjust_numeric_range(lower_limit = 2) %>%
-        adjust_numeric_calibration(dummy_reg_cal) %>% adjust_predictions_custom(
-        squared = .pred^2)
+        adjust_numeric_calibration() %>% adjust_predictions_custom(squared = .pred^2)
     Condition
       Error in `adjust_numeric_calibration()`:
       ! Calibration should come before other operations.
@@ -12,20 +11,20 @@
 
     Code
       container(mode = "classification") %>% adjust_probability_threshold(threshold = 0.4) %>%
-        adjust_probability_calibration(dummy_cls_cal)
+        adjust_probability_calibration()
     Condition
       Error in `adjust_probability_calibration()`:
-      ! Operations that change the hard class predictions must come after operations that update the class probability estimates.
+      ! `type` must be a string or character vector.
 
 ---
 
     Code
       container(mode = "classification") %>% adjust_predictions_custom(veg = "potato") %>%
         adjust_probability_threshold(threshold = 0.4) %>%
-        adjust_probability_calibration(dummy_cls_cal)
+        adjust_probability_calibration()
     Condition
       Error in `adjust_probability_calibration()`:
-      ! Operations that change the hard class predictions must come after operations that update the class probability estimates.
+      ! `type` must be a string or character vector.
 
 ---
 
@@ -33,7 +32,7 @@
       container(mode = "classification") %>% adjust_predictions_custom(veg = "potato") %>%
         adjust_probability_threshold(threshold = 0.4) %>%
         adjust_probability_threshold(threshold = 0.5) %>%
-        adjust_probability_calibration(dummy_cls_cal)
+        adjust_probability_calibration()
     Condition
       Error in `adjust_probability_threshold()`:
       ! Operations cannot be duplicated: "probability_threshold"

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,2 +1,2 @@
 ctr_cls <- container(mode = "classification")
-ctr_reg <- container(mode = "classification")
+ctr_reg <- container(mode = "regression")

--- a/tests/testthat/test-adjust-numeric-calibration.R
+++ b/tests/testthat/test-adjust-numeric-calibration.R
@@ -1,13 +1,23 @@
 test_that("adjustment printing", {
-  dummy_reg_cal <- structure(list(), class = "cal_regression")
-  expect_snapshot(ctr_reg %>% adjust_numeric_calibration(dummy_reg_cal))
+  expect_snapshot(ctr_reg %>% adjust_numeric_calibration())
 })
 
 test_that("errors informatively with bad input", {
   # check for `adjust_numeric_calibration(container)` is in `utils.R` tests
 
-  expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_reg))
   expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_reg, "boop"))
-  dummy_cls_cal <- structure(list(), class = "cal_binary")
-  expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_cls, dummy_cls_cal))
+  expect_snapshot(
+    error = TRUE,
+    container("classification", "binary") %>% adjust_numeric_calibration("linear")
+  )
+  # todo: this should error, all is fine besides the fn name
+  # expect_snapshot(
+  #   error = TRUE,
+  #   container("classification", "binary") %>% adjust_numeric_calibration("binary")
+  # )
+  # todo: this should error, mode is incompatible even though type is fine
+  # expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_cls, "linear"))
+
+  expect_no_condition(adjust_numeric_calibration(ctr_reg))
+  expect_no_condition(adjust_numeric_calibration(ctr_reg, "linear"))
 })

--- a/tests/testthat/test-adjust-numeric-calibration.R
+++ b/tests/testthat/test-adjust-numeric-calibration.R
@@ -10,11 +10,10 @@ test_that("errors informatively with bad input", {
     error = TRUE,
     container("classification", "binary") %>% adjust_numeric_calibration("linear")
   )
-  # todo: this should error, all is fine besides the fn name
-  # expect_snapshot(
-  #   error = TRUE,
-  #   container("classification", "binary") %>% adjust_numeric_calibration("binary")
-  # )
+  expect_snapshot(
+    error = TRUE,
+    container("regression", "regression") %>% adjust_numeric_calibration("binary")
+  )
   # todo: this should error, mode is incompatible even though type is fine
   # expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_cls, "linear"))
 

--- a/tests/testthat/test-adjust-probability-calibration.R
+++ b/tests/testthat/test-adjust-probability-calibration.R
@@ -10,10 +10,10 @@ test_that("errors informatively with bad input", {
     error = TRUE,
     container("regression", "regression") %>% adjust_probability_calibration("binary")
   )
-  # todo: this should error, all is fine besides the fn name
-  # expect_snapshot(
-  #   container("regression", "regression") %>% adjust_probability_calibration("linear")
-  # )
+  expect_snapshot(
+    error = TRUE,
+    container("classification", "binary") %>% adjust_probability_calibration("linear")
+  )
   # todo: this should error, mode is incompatible even though type is fine
   # expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_cls, "linear"))
 

--- a/tests/testthat/test-adjust-probability-calibration.R
+++ b/tests/testthat/test-adjust-probability-calibration.R
@@ -1,16 +1,22 @@
 test_that("adjustment printing", {
-  dummy_cls_cal <- structure(list(), class = "cal_binary")
-  expect_snapshot(ctr_cls %>% adjust_probability_calibration(dummy_cls_cal))
+  expect_snapshot(ctr_cls %>% adjust_probability_calibration("logistic"))
 })
 
 test_that("errors informatively with bad input", {
   # check for `adjust_probably_calibration(container)` is in `utils.R` tests
 
-  expect_snapshot(error = TRUE, adjust_probability_calibration(ctr_cls))
   expect_snapshot(error = TRUE, adjust_probability_calibration(ctr_cls, "boop"))
-  dummy_reg_cal <- structure(list(), class = "cal_regression")
   expect_snapshot(
     error = TRUE,
-    adjust_probability_calibration(ctr_cls, dummy_reg_cal)
+    container("regression", "regression") %>% adjust_probability_calibration("binary")
   )
+  # todo: this should error, all is fine besides the fn name
+  # expect_snapshot(
+  #   container("regression", "regression") %>% adjust_probability_calibration("linear")
+  # )
+  # todo: this should error, mode is incompatible even though type is fine
+  # expect_snapshot(error = TRUE, adjust_numeric_calibration(ctr_cls, "linear"))
+
+  expect_no_condition(adjust_numeric_calibration(ctr_reg))
+  expect_no_condition(adjust_numeric_calibration(ctr_reg, "linear"))
 })

--- a/tests/testthat/test-validation-rules.R
+++ b/tests/testthat/test-validation-rules.R
@@ -1,11 +1,8 @@
 test_that("validation of operations (regression)", {
-  dummy_reg_cal <- list()
-  class(dummy_reg_cal) <- "cal_regression"
-
   expect_silent(
     reg_ctr <-
       container(mode = "regression") %>%
-      adjust_numeric_calibration(dummy_reg_cal) %>%
+      adjust_numeric_calibration() %>%
       adjust_numeric_range(lower_limit = 2) %>%
       adjust_predictions_custom(squared = .pred^2)
   )
@@ -13,7 +10,7 @@ test_that("validation of operations (regression)", {
   expect_snapshot(
     container(mode = "regression") %>%
       adjust_numeric_range(lower_limit = 2) %>%
-      adjust_numeric_calibration(dummy_reg_cal) %>%
+      adjust_numeric_calibration() %>%
       adjust_predictions_custom(squared = .pred^2),
     error = TRUE
   )
@@ -24,19 +21,17 @@ test_that("validation of operations (regression)", {
     reg_ctr <-
       container(mode = "regression") %>%
       adjust_predictions_custom(squared = .pred^2) %>%
-      adjust_numeric_calibration(dummy_reg_cal) %>%
+      adjust_numeric_calibration() %>%
       adjust_numeric_range(lower_limit = 2)
   )
 })
 
 test_that("validation of operations (classification)", {
-  dummy_cls_cal <- list()
-  class(dummy_cls_cal) <- "cal_binary"
-
   expect_silent(
     cls_ctr_1 <-
       container(mode = "classification") %>%
-      adjust_probability_calibration(dummy_cls_cal) %>%
+      # to-do: should be able to supply no `type` argument here
+      adjust_probability_calibration("logistic") %>%
       adjust_probability_threshold(threshold = .4)
   )
 
@@ -45,14 +40,14 @@ test_that("validation of operations (classification)", {
       container(mode = "classification") %>%
       adjust_predictions_custom(starch = "potato") %>%
       adjust_predictions_custom(veg = "green beans") %>%
-      adjust_probability_calibration(dummy_cls_cal) %>%
+      adjust_probability_calibration("logistic") %>%
       adjust_probability_threshold(threshold = .4)
   )
 
   expect_snapshot(
     container(mode = "classification") %>%
       adjust_probability_threshold(threshold = .4) %>%
-      adjust_probability_calibration(dummy_cls_cal),
+      adjust_probability_calibration(),
     error = TRUE
   )
 
@@ -60,7 +55,7 @@ test_that("validation of operations (classification)", {
     container(mode = "classification") %>%
       adjust_predictions_custom(veg = "potato") %>%
       adjust_probability_threshold(threshold = .4) %>%
-      adjust_probability_calibration(dummy_cls_cal),
+      adjust_probability_calibration(),
     error = TRUE
   )
 
@@ -69,7 +64,7 @@ test_that("validation of operations (classification)", {
       adjust_predictions_custom(veg = "potato") %>%
       adjust_probability_threshold(threshold = .4) %>%
       adjust_probability_threshold(threshold = .5) %>%
-      adjust_probability_calibration(dummy_cls_cal),
+      adjust_probability_calibration(),
     error = TRUE
   )
 


### PR DESCRIPTION
Closes #9.

Before this PR, interface was:

``` r
 library(container)
 library(modeldata)
 library(probably)
#> 
#> Attaching package: 'probably'
#> The following objects are masked from 'package:base':
#> 
#>     as.factor, as.ordered
 library(tibble)

 # create example data
 set.seed(1)
 dat <- tibble(y = rnorm(100), y_pred = y/2 + rnorm(100))

 dat
#> # A tibble: 100 × 2
#>         y y_pred
#>     <dbl>  <dbl>
#>  1 -0.626 -0.934
#>  2  0.184  0.134
#>  3 -0.836 -1.33 
#>  4  1.60   0.956
#>  5  0.330 -0.490
#>  6 -0.820  1.36 
#>  7  0.487  0.960
#>  8  0.738  1.28 
#>  9  0.576  0.672
#> 10 -0.305  1.53 
#> # ℹ 90 more rows

 # calibrate numeric predictions
 reg_cal <- cal_estimate_linear(dat, truth = y, estimate = y_pred)

 # specify calibration
 reg_ctr <-
   container(mode = "regression") %>%
   adjust_numeric_calibration(reg_cal)

 # "train" container
 reg_ctr_trained <- fit(reg_ctr, dat, outcome = y, estimate = y_pred)

 predict(reg_ctr, dat)
#> # A tibble: 100 × 2
#>         y  y_pred
#>     <dbl>   <dbl>
#>  1 -0.626 -0.257 
#>  2  0.184  0.303 
#>  3 -0.836 -0.512 
#>  4  1.60   0.479 
#>  5  0.330  0.0108
#>  6 -0.820  0.523 
#>  7  0.487  0.480 
#>  8  0.738  0.516 
#>  9  0.576  0.438 
#> 10 -0.305  0.536 
#> # ℹ 90 more rows
```

<sup>Created on 2024-04-26 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

With this PR:

``` r
library(container)
library(modeldata)
library(probably)
#> 
#> Attaching package: 'probably'
#> The following objects are masked from 'package:base':
#> 
#>     as.factor, as.ordered
library(tibble)

# create example data
set.seed(1)
dat <- tibble(y = rnorm(100), y_pred = y/2 + rnorm(100))

dat
#> # A tibble: 100 × 2
#>         y y_pred
#>     <dbl>  <dbl>
#>  1 -0.626 -0.934
#>  2  0.184  0.134
#>  3 -0.836 -1.33 
#>  4  1.60   0.956
#>  5  0.330 -0.490
#>  6 -0.820  1.36 
#>  7  0.487  0.960
#>  8  0.738  1.28 
#>  9  0.576  0.672
#> 10 -0.305  1.53 
#> # ℹ 90 more rows

# specify calibration
reg_ctr <-
  container(mode = "regression") %>%
  adjust_numeric_calibration(type = "linear")

# train container
reg_ctr_trained <- fit(reg_ctr, dat, outcome = y, estimate = y_pred)

predict(reg_ctr_trained, dat)
#> # A tibble: 100 × 2
#>         y  y_pred
#>     <dbl>   <dbl>
#>  1 -0.626 -0.257 
#>  2  0.184  0.303 
#>  3 -0.836 -0.512 
#>  4  1.60   0.479 
#>  5  0.330  0.0108
#>  6 -0.820  0.523 
#>  7  0.487  0.480 
#>  8  0.738  0.516 
#>  9  0.576  0.438 
#> 10 -0.305  0.536 
#> # ℹ 90 more rows
```

<sup>Created on 2024-04-26 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Will be followed up by workflows PR updates (tidymodels/workflows#225) and a tune PR later today.